### PR TITLE
Add support to update categories of a message, delta synching, sending of drafts

### DIFF
--- a/grapi/api/v1/api.py
+++ b/grapi/api/v1/api.py
@@ -148,6 +148,9 @@ class API(BaseAPI):
                 self.add_route(user + '/mailFolders/{folderid}/messages/{itemid}',
                                messages, suffix="message_by_folderid")
 
+                # Delta sync directory
+                self.add_route(user + '/mailFolders/{folderid}/messages/delta', messages, suffix="delta")
+
                 # Message attachments
                 self.add_route(user + '/messages/{itemid}/attachments',
                                attachments, suffix="by_id")

--- a/grapi/api/v1/api.py
+++ b/grapi/api/v1/api.py
@@ -101,6 +101,7 @@ class API(BaseAPI):
 
             self.add_route(PREFIX + '/groups', groups)
             self.add_route(PREFIX + '/groups/{groupid}', groups)
+            self.add_route(PREFIX + '/groups/{groupid}/members', groups, suffix="members")
 
             for user in (PREFIX + '/me', PREFIX + '/users/{userid}'):
                 self.add_route(user + '/contactFolders/', contactfolders, suffix="contact_folders")

--- a/grapi/api/v1/api.py
+++ b/grapi/api/v1/api.py
@@ -198,6 +198,16 @@ class API(BaseAPI):
                     messages, suffix="move"
                 )
 
+                # Message send.
+                self.add_route(
+                    user + '/messages/{itemid}/send',
+                    messages, suffix="send"
+                )
+                self.add_route(
+                    user + '/mailFolders/{folderid}/messages/{itemid}/send',
+                    messages, suffix="send"
+                )
+
                 # Message createReply.
                 self.add_route(
                     user + '/messages/{itemid}/createReply',

--- a/grapi/backend/kopano/group.py
+++ b/grapi/backend/kopano/group.py
@@ -51,6 +51,14 @@ class GroupResource(Resource):
         data = (user.groups(), DEFAULT_TOP, 0, 0)
         self.respond(req, resp, data, self.fields)
 
+    def on_get_members(self, req, resp, groupid):
+        server, _, userid = req.context.server_store
+
+        if not groupid:
+            groupid = req.path.split('/')[-2]
+
+        self.handle_get_members(req, resp, server, groupid)
+
     def on_get(self, req, resp, userid=None, groupid=None, method=None):
         handler = None
 

--- a/grapi/backend/kopano/group.py
+++ b/grapi/backend/kopano/group.py
@@ -52,6 +52,13 @@ class GroupResource(Resource):
         self.respond(req, resp, data, self.fields)
 
     def on_get_members(self, req, resp, groupid):
+        """Return members by group ID.
+
+        Args:
+            req (Request): Falcon request object.
+            resp (Response): Falcon response object.
+            groupid (str): group ID.
+        """
         server = req.context.server_store[0]
 
         self.handle_get_members(req, resp, server, groupid)

--- a/grapi/backend/kopano/group.py
+++ b/grapi/backend/kopano/group.py
@@ -52,10 +52,7 @@ class GroupResource(Resource):
         self.respond(req, resp, data, self.fields)
 
     def on_get_members(self, req, resp, groupid):
-        server, _, userid = req.context.server_store
-
-        if not groupid:
-            groupid = req.path.split('/')[-2]
+        server, _, _ = req.context.server_store
 
         self.handle_get_members(req, resp, server, groupid)
 

--- a/grapi/backend/kopano/group.py
+++ b/grapi/backend/kopano/group.py
@@ -52,7 +52,7 @@ class GroupResource(Resource):
         self.respond(req, resp, data, self.fields)
 
     def on_get_members(self, req, resp, groupid):
-        server, _, _ = req.context.server_store
+        server = req.context.server_store[0]
 
         self.handle_get_members(req, resp, server, groupid)
 

--- a/grapi/backend/kopano/message.py
+++ b/grapi/backend/kopano/message.py
@@ -253,6 +253,10 @@ class MessageResource(ItemResource):
             resp (Response): Falcon response object.
             itemid (str): message ID. Defaults to None. itemid value is mandatory.
         """
+
+        if itemid is None:
+            raise HTTPNotFound()
+
         store = req.context.server_store[1]
         item = _item(store, itemid)
         self._handle_post_send(req, resp, item)

--- a/grapi/backend/kopano/message.py
+++ b/grapi/backend/kopano/message.py
@@ -161,7 +161,6 @@ class MessageResource(ItemResource):
         Raises:
             HTTPNotFound: when folderid is None.
         """
-
         if folderid is None:
             raise HTTPNotFound()
         store = req.context.server_store[1]

--- a/grapi/backend/kopano/message.py
+++ b/grapi/backend/kopano/message.py
@@ -56,6 +56,16 @@ def update_attr_value(item, attr_name, value):
     setattr(item, attr_name, value)
 
 
+def set_categories(item, value):
+    """Update categories value of an item.
+
+    Args:
+        item (Item): item object.
+        value (list): attribute value.
+    """
+    item.categories = value
+
+
 def get_internet_headers(item):
     """Format the RFC5322 Message Headers as specified by Microsoft Graph
 
@@ -119,6 +129,7 @@ class MessageResource(ItemResource):
         'from': lambda item, arg: set_user_email(item, 'from_', arg),
         'sender': lambda item, arg: set_user_email(item, 'sender', arg),
         'isRead': lambda item, value: update_attr_value(item, "read", value),
+        'categories': lambda item, value: set_categories(item, value),
     }
 
     deleted_resource = DeletedMessageResource

--- a/grapi/backend/kopano/message.py
+++ b/grapi/backend/kopano/message.py
@@ -56,16 +56,6 @@ def update_attr_value(item, attr_name, value):
     setattr(item, attr_name, value)
 
 
-def set_categories(item, value):
-    """Update categories value of an item.
-
-    Args:
-        item (Item): item object.
-        value (list): attribute value.
-    """
-    item.categories = value
-
-
 def get_internet_headers(item):
     """Format the RFC5322 Message Headers as specified by Microsoft Graph
 
@@ -129,7 +119,7 @@ class MessageResource(ItemResource):
         'from': lambda item, arg: set_user_email(item, 'from_', arg),
         'sender': lambda item, arg: set_user_email(item, 'sender', arg),
         'isRead': lambda item, value: update_attr_value(item, "read", value),
-        'categories': lambda item, value: set_categories(item, value),
+        'categories': lambda item, value: update_attr_value(item, 'categories', value),
     }
 
     deleted_resource = DeletedMessageResource

--- a/grapi/backend/kopano/message.py
+++ b/grapi/backend/kopano/message.py
@@ -150,6 +150,25 @@ class MessageResource(ItemResource):
         data = self.folder_gen(req, store.inbox)
         self.respond(req, resp, data, MessageResource.fields)
 
+    def on_get_delta(self, req, resp, folderid=None):
+        """Get delta messages sync by folder ID.
+
+        Args:
+            req (Request): Falcon request object.
+            resp (Response): Falcon response object.
+            folderid (str): folder ID. Defaults to None. folderid value is mandatory
+
+        Raises:
+            HTTPNotFound: when folderid is None.
+        """
+
+        if folderid is None:
+            raise HTTPNotFound()
+
+        store = req.context.server_store[1]
+        folder = _folder(store, folderid)
+        self._handle_get_delta(req, resp, store=store, folder=folder)
+
     def on_get_item(self, req, resp, folderid=None, itemid=None):
         """Get a message by folder ID.
 
@@ -165,15 +184,12 @@ class MessageResource(ItemResource):
         Note:
             Based on MS Explorer result, it never validate folderid. So, we ignore it.
         """
-        store = req.context.server_store[1]
         if itemid is None:
             raise HTTPNotFound()
-        elif itemid == 'delta':  # TODO move to MailFolder resource somehow?
-            folder = _folder(store, folderid)
-            self._handle_get_delta(req, resp, store=store, folder=folder)
-        else:
-            item = _item(store, itemid)
-            self.respond(req, resp, item)
+
+        store = req.context.server_store[1]
+        item = _item(store, itemid)
+        self.respond(req, resp, item)
 
     def on_get_messages_by_folderid(self, req, resp, folderid):
         store = req.context.server_store[1]

--- a/grapi/backend/kopano/message.py
+++ b/grapi/backend/kopano/message.py
@@ -251,9 +251,21 @@ class MessageResource(ItemResource):
         self.respond(req, resp, item.reply(all=True))
         resp.status = falcon.HTTP_201
 
-    def handle_post_send(self, req, resp, store, folder, item):
+    def _handle_post_send(self, req, resp, item):
         item.send()
         resp.status = falcon.HTTP_202
+
+    def on_post_send(self, req, resp, itemid=None):
+        """Handle POST request on 'send' action.
+
+        Args:
+            req (Request): Falcon request object.
+            resp (Response): Falcon response object.
+            itemid (str): message ID. Defaults to None. itemid value is mandatory.
+        """
+        store = req.context.server_store[1]
+        item = _item(store, itemid)
+        self._handle_post_send(req, resp, item)
 
     def _create_message(self, req, resp, folderid):
         """Create a new message in a defined folder.

--- a/grapi/backend/kopano/message.py
+++ b/grapi/backend/kopano/message.py
@@ -269,7 +269,6 @@ class MessageResource(ItemResource):
             resp (Response): Falcon response object.
             itemid (str): message ID. Defaults to None. itemid value is mandatory.
         """
-
         if itemid is None:
             raise HTTPNotFound()
 

--- a/grapi/backend/kopano/message.py
+++ b/grapi/backend/kopano/message.py
@@ -164,7 +164,6 @@ class MessageResource(ItemResource):
 
         if folderid is None:
             raise HTTPNotFound()
-
         store = req.context.server_store[1]
         folder = _folder(store, folderid)
         self._handle_get_delta(req, resp, store=store, folder=folder)

--- a/grapi/backend/kopano/message.py
+++ b/grapi/backend/kopano/message.py
@@ -175,11 +175,15 @@ class MessageResource(ItemResource):
         Note:
             Based on MS Explorer result, it never validate folderid. So, we ignore it.
         """
+        store = req.context.server_store[1]
         if itemid is None:
             raise HTTPNotFound()
-        store = req.context.server_store[1]
-        item = _item(store, itemid)
-        self.respond(req, resp, item)
+        elif itemid == 'delta':  # TODO move to MailFolder resource somehow?
+            folder = _folder(store, folderid)
+            self._handle_get_delta(req, resp, store=store, folder=folder)
+        else:
+            item = _item(store, itemid)
+            self.respond(req, resp, item)
 
     def on_get_messages_by_folderid(self, req, resp, folderid):
         store = req.context.server_store[1]


### PR DESCRIPTION
For some reasons, the setattr method does not work for the categories of a message. Hence, the update_attr_value method does also not work.

Therefore, I have added an explicit method set_categories, which sets item.categories directly.