### PR TITLE
Add support for embedded attachments

### DIFF
--- a/grapi/api/v1/api.py
+++ b/grapi/api/v1/api.py
@@ -152,12 +152,20 @@ class API(BaseAPI):
                                attachments, suffix="by_id")
                 self.add_route(user + '/messages/{itemid}/attachments/{attachmentid}',
                                attachments, suffix="by_id")
+                self.add_route(user + '/messages/{itemid}/attachments/{attachmentid}/item',
+                               attachments, suffix="embedded_item_by_id")
+                self.add_route(user + '/messages/{itemid}/attachments/{attachmentid}/item/$value',
+                               messages, suffix="embedded_value")
                 self.add_route(user + '/messages/{itemid}/attachments/{attachmentid}/$value',
                                attachments, suffix="binary_by_id")
                 self.add_route(user + '/mailFolders/{folderid}/messages/{itemid}/attachments',
                                attachments, suffix="in_folder_by_id")
                 self.add_route(user + '/mailFolders/{folderid}/messages/{itemid}/attachments/{attachmentid}',
                                attachments, suffix="in_folder_by_id")
+                self.add_route(user + '/mailFolders/{folderid}/messages/{itemid}/attachments/{attachmentid}/item',
+                               attachments, suffix="embedded_item_by_id")
+                self.add_route(user + '/mailFolders/{folderid}/messages/{itemid}/attachments/{attachmentid}/item/$value',
+                               messages, suffix="embedded_folder_value")
                 self.add_route(user + '/mailFolders/{folderid}/messages/{itemid}/attachments/{attachmentid}/$value',
                                attachments, suffix="binary_in_folder_by_id")
 

--- a/grapi/backend/kopano/message.py
+++ b/grapi/backend/kopano/message.py
@@ -1,6 +1,8 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 import falcon
 
+import inetmapi
+
 from grapi.api.v1.schema import message as message_schema
 
 from . import attachment  # import as module since this is a circular import
@@ -124,7 +126,7 @@ class MessageResource(ItemResource):
     deleted_resource = DeletedMessageResource
 
     relations = {
-        'attachments': lambda message: (message.attachments, attachment.FileAttachmentResource),  # TODO embedded
+        'attachments': lambda message: (message.attachments(embedded=True), attachment.FileAttachmentResource),  # TODO embedded
     }
 
     # GET
@@ -175,6 +177,49 @@ class MessageResource(ItemResource):
         data = _folder(store, folderid)
         data = self.folder_gen(req, data)
         self.respond(req, resp, data, MessageResource.fields)
+
+    def on_get_embedded_folder_value(self, req, resp, folderid=None, itemid=None, attachmentid=None):
+        """Get a message as RFC-2822 by item and attachment ID including a folderid.
+
+        Args:
+            req (Request): Falcon request object.
+            resp (Response): Falcon response object.
+            folderid (str): folder ID. Defaults to None.
+            itemid (str): message ID. Defaults to None. itemid value is mandatory.
+            attachmentid (str): message ID. Defaults to None. attachmentid value is mandatory.
+
+        Raises:
+            HTTPNotFound: when itemid or attachmentid is None.
+
+        Note:
+            Based on MS Explorer result, it never validate folderid. So, we ignore it.
+        """
+        if itemid is None or attachmentid is None:
+            raise HTTPNotFound()
+        self.on_get_embedded_value(self, req, resp, itemid, attachmentid)
+
+    def on_get_embedded_value(self, req, resp, itemid=None, attachmentid=None):
+        """Get a message as RFC-2822 by item and attachment ID.
+
+        Args:
+            req (Request): Falcon request object.
+            resp (Response): Falcon response object.
+            itemid (str): message ID. Defaults to None. itemid value is mandatory.
+            attachmentid (str): message ID. Defaults to None. attachmentid value is mandatory.
+
+        Raises:
+            HTTPNotFound: when itemid or attachmentid is None.
+        """
+        if itemid is None or attachmentid is None:
+            raise HTTPNotFound()
+        store = req.context.server_store[1]
+        item = _item(store, itemid)
+        attachment = item.attachment(attachmentid)
+        embedded_item = attachment.item
+        # Super ugly hack to get data of embedded items and make them available (not available via kopano-python)
+        sopt = inetmapi.sending_options()
+        resp.body = inetmapi.IMToINet(store.server.mapisession, None, embedded_item.mapiobj, sopt).decode()
+        resp.content_type = "text/plain"
 
     def on_get_value(self, req, resp, folderid=None, itemid=None):
         """Get a message as RFC-2822 by folder ID.


### PR DESCRIPTION
Most of the bits were there already. Encapsulating field sets per attachments in a tuple was already there to be read. Just had to be implemented in the respective function. Support for referenceAttachments should be easy to implement.

I have based that still on master as the other pull request has not been merged yet.